### PR TITLE
Added support to do reverse proxy over https while proxy_pass over http

### DIFF
--- a/docket/docket.py
+++ b/docket/docket.py
@@ -22,12 +22,14 @@
 from application import Application
 import os
 
+from reverseproxied import ReverseProxied
+
 my_app = Application(environment=os.environ)
 celery = my_app.celery()
 
 import tasks
 
-app = my_app.flask_app
+app = ReverseProxied(my_app.flask_app)
 if __name__ == '__main__':
     app.logger.info("Running {}".format(app.flask_app.name))
     app.run()

--- a/docket/reverseproxied.py
+++ b/docket/reverseproxied.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+class ReverseProxied(object):
+    '''Wrap the application in this middleware and configure the
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+    location /myprefix {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /myprefix;
+        }
+
+    :param app: the WSGI application
+    '''
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+
+        scheme = environ.get('HTTP_X_SCHEME', '')
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        return self.app(environ, start_response)
+


### PR DESCRIPTION
I'm using docket on a server with multiple web services. Instead of having different ports I set them up to different URIs on the same server using nginx as reverseproxy. I prefer all traffic outside of the box on HTTPS but don't want that for proxy_pass. This snippet is borrowed from http://flask.pocoo.org/snippets/35/ and allow redirects to work while maintaining HTTPS.